### PR TITLE
chore: Return type을 필수로 넣어줘야하는 eslint option 제거

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
 {
   "plugins": [
     "react",
@@ -39,7 +41,8 @@
       { "blankLine": "always", "prev": "*", "next": "return" },
       { "blankLine": "always", "prev": ["const", "let", "var"], "next": "*" },
       { "blankLine": "any", "prev": ["const", "let", "var"], "next": ["const", "let", "var"] }
-    ]
+    ],
+    "@typescript-eslint/explicit-module-boundary-types": false
   },
   "settings": {
     "import/resolver": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,7 +42,7 @@
       { "blankLine": "always", "prev": ["const", "let", "var"], "next": "*" },
       { "blankLine": "any", "prev": ["const", "let", "var"], "next": ["const", "let", "var"] }
     ],
-    "@typescript-eslint/explicit-module-boundary-types": false
+    "@typescript-eslint/explicit-module-boundary-types": "off"
   },
   "settings": {
     "import/resolver": {


### PR DESCRIPTION
`@typescript-eslint/explicit-module-boundary-types` 옵션 `false`로 설정