### PR TITLE
fix: youtubeIcon asset name 변경

### DIFF
--- a/public/assets/index.ts
+++ b/public/assets/index.ts
@@ -1,12 +1,12 @@
 export { default as Alphabet } from './icons/Alphabet.svg';
+export { default as CopyIcon } from './icons/CopyIcon.svg';
 export { default as dropDownIcon } from './icons/dropDownIcon.svg';
+export { default as FavoriteIcon } from './icons/FavoriteIcon.svg';
+export { default as hoverYoutubeIcon } from './icons/hoverYoutubeIcon.svg';
 export { default as offStep1 } from './icons/offStep1.svg';
 export { default as offStep2 } from './icons/offStep2.svg';
 export { default as onStep1 } from './icons/onStep1.svg';
 export { default as onStep2 } from './icons/onStep2.svg';
 export { default as sizeDown } from './icons/sizeDown.svg';
 export { default as sizeUp } from './icons/sizeUp.svg';
-export { default as CopyIcon } from './icons/CopyIcon.svg';
-export { default as FavoriteIcon } from './icons/FavoriteIcon.svg';
-export { default as hoverYoutubeIcon } from './icons/hoverYoutubeIcon.svg';
-export { default as YoutubeIcon } from './icons/YoutubeIcon.svg';
+export { default as YoutubeIcon } from './icons/youtubeIcon.svg';


### PR DESCRIPTION

## 📝 PR 요약

- Asset export 경로 문제로 빌드 에러가 발생하여 `youtubeIcon` asset name 변경


